### PR TITLE
Fix : le background de la page principale devrait maintenant prendre la place disponible

### DIFF
--- a/exoweb/src/pages/home.css
+++ b/exoweb/src/pages/home.css
@@ -110,6 +110,7 @@
     width: 100%;
     object-fit: cover;
     z-index: -10;
+    height: 90%;
 }
 
 .bottom-boat {


### PR DESCRIPTION
J'avais changé de quoi dans mon dernier PR qui fait que l'image ne prenait pas toute la place (on voyait du blanc derrière) sur les écrans HD. J'avais pas bien testé mes affaires...

J'ai remis à peu près comme c'était avant (90% à la place de 100%). Ça marche bien sur les displays HD (qui sont les plus communs je pense), mais on voit pas bien les bateaux sur les displays de plus haute résolution, je vous laisse juger si c'est important pour vous.